### PR TITLE
Preserve extension for generated upload names and avoid collisions

### DIFF
--- a/Services/FileService.cs
+++ b/Services/FileService.cs
@@ -68,7 +68,20 @@ namespace MyPhotoBiz.Services
             if (!Directory.Exists(uploadPath))
                 Directory.CreateDirectory(uploadPath);
 
-            var filePath = Path.Combine(uploadPath, file.FileName);
+            var originalExtension = Path.GetExtension(file.FileName);
+            var fileName = Path.GetFileName(file.FileName);
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                fileName = $"upload_{Guid.NewGuid():N}{originalExtension}";
+            }
+            var filePath = Path.Combine(uploadPath, fileName);
+            while (System.IO.File.Exists(filePath))
+            {
+                var baseName = Path.GetFileNameWithoutExtension(fileName);
+                var extension = Path.GetExtension(fileName);
+                fileName = $"{baseName}_{Guid.NewGuid():N}{extension}";
+                filePath = Path.Combine(uploadPath, fileName);
+            }
             using (var stream = new FileStream(filePath, FileMode.Create))
             {
                 await file.CopyToAsync(stream);
@@ -76,8 +89,8 @@ namespace MyPhotoBiz.Services
 
             var fileItem = new FileItem
             {
-                Name = file.FileName,
-                Type = Path.GetExtension(file.FileName).Trim('.').ToUpper(),
+                Name = fileName,
+                Type = Path.GetExtension(fileName).Trim('.').ToUpper(),
                 Size = file.Length,
                 Modified = DateTime.Now,
                 Owner = owner,


### PR DESCRIPTION
### Motivation
- Ensure generated fallback upload names keep the original file extension so type detection remains accurate.
- Prevent accidental overwrites when multiple uploads use the same file name by guaranteeing unique stored filenames.

### Description
- In `Services/FileService.cs` use `Path.GetExtension(file.FileName)` and `Path.GetFileName(file.FileName)` to derive a sanitized `fileName` and include the original extension in fallback names.
- When the sanitized name is empty, generate a fallback name of the form `upload_{Guid}{extension}` to preserve extension information.
- Add collision handling that checks `System.IO.File.Exists` and appends a GUID suffix to the base name until a unique `filePath` is found, and store the final `fileName` in the `FileItem` (with `Type` derived from that name).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69732439decc832894c75d06d8387491)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced file upload robustness with automatic collision detection to prevent file overwrites
* Generates safe, unique file names for all uploads, with automatic fallback naming for problematic uploads
* Improved file type detection and storage reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->