### PR TITLE
Add customizable dashboard widgets (reorder & hide)

### DIFF
--- a/Views/Home/Dashboard.cshtml
+++ b/Views/Home/Dashboard.cshtml
@@ -404,9 +404,19 @@
         </div>
     }
 
-<!-- Client Proofs Quick Access -->
-<div class="row mb-4">
-    <div class="col-12">
+<div class="d-flex align-items-center justify-content-between mt-4 mb-2">
+    <div>
+        <h4 class="mb-0">Dashboard Widgets</h4>
+        <small class="text-muted">Choose which widgets appear and drag to reorder them.</small>
+    </div>
+    <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="modal" data-bs-target="#dashboardWidgetModal">
+        <i class="ti ti-adjustments-horizontal me-1"></i> Customize Widgets
+    </button>
+</div>
+
+<div id="dashboard-widgets" class="row g-4">
+    <!-- Client Proofs Quick Access -->
+    <div class="col-12" data-dashboard-widget data-widget-id="client-proofs" data-widget-title="Client Proofs">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="card-title mb-0">
@@ -445,13 +455,9 @@
             </div>
         </div>
     </div>
-</div>
-
-<!-- Bottom Row: Upcoming Shoots + Recent Activity -->
-<div class="row g-4">
 
     <!-- Upcoming Photo Shoots -->
-    <div class="col-xxl-4 col-xl-6">
+    <div class="col-xxl-4 col-xl-6" data-dashboard-widget data-widget-id="upcoming-shoots" data-widget-title="Upcoming Shoots">
         <div class="card dashboard-card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="card-title mb-0">Upcoming Shoots</h5>
@@ -517,7 +523,7 @@
     </div>
 
     <!-- Recent Invoices -->
-    <div class="col-xxl-4 col-xl-6">
+    <div class="col-xxl-4 col-xl-6" data-dashboard-widget data-widget-id="recent-invoices" data-widget-title="Recent Invoices">
         <div class="card dashboard-card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="card-title mb-0">Recent Invoices</h5>
@@ -590,7 +596,7 @@
     </div>
 
     <!-- Recent Activity -->
-    <div class="col-xxl-4">
+    <div class="col-xxl-4" data-dashboard-widget data-widget-id="recent-activity" data-widget-title="Recent Activity">
         <div class="card dashboard-card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="card-title mb-0">Recent Activity</h5>
@@ -631,6 +637,28 @@
                         <p>No recent activity</p>
                     </div>
                 }
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="dashboardWidgetModal" tabindex="-1" aria-labelledby="dashboardWidgetModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="dashboardWidgetModalLabel">Customize Widgets</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted small mb-3">
+                    Drag to reorder widgets and toggle the ones you want to see on your dashboard.
+                </p>
+                <ul class="list-group" id="dashboard-widget-list"></ul>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-link text-decoration-none" id="dashboard-widget-reset">Reset</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="dashboard-widget-save" data-bs-dismiss="modal">Save</button>
             </div>
         </div>
     </div>
@@ -716,6 +744,19 @@
     border-radius: 3px;
 }
 
+.dashboard-widget-item {
+    cursor: grab;
+    user-select: none;
+}
+
+.dashboard-widget-item.dragging {
+    opacity: 0.6;
+}
+
+.dashboard-widget-handle {
+    cursor: grab;
+}
+
 </style>
 
 @section Scripts {
@@ -764,6 +805,171 @@
                     }
                 });
             }
+
+            var widgetContainer = document.getElementById('dashboard-widgets');
+            if (!widgetContainer) {
+                return;
+            }
+
+            var storageKey = 'myPhotoBiz.dashboard.widgets';
+            var widgetList = document.getElementById('dashboard-widget-list');
+            var widgetSave = document.getElementById('dashboard-widget-save');
+            var widgetReset = document.getElementById('dashboard-widget-reset');
+            var widgets = Array.from(widgetContainer.querySelectorAll('[data-dashboard-widget]'));
+            var defaultOrder = widgets.map(function(widget) { return widget.dataset.widgetId; });
+
+            function loadState() {
+                var saved = localStorage.getItem(storageKey);
+                if (!saved) {
+                    return null;
+                }
+                try {
+                    return JSON.parse(saved);
+                } catch (error) {
+                    return null;
+                }
+            }
+
+            function saveState(state) {
+                localStorage.setItem(storageKey, JSON.stringify(state));
+            }
+
+            function getOrder(stateOrder) {
+                var ordering = Array.isArray(stateOrder) && stateOrder.length ? stateOrder.slice() : [];
+                defaultOrder.forEach(function(id) {
+                    if (!ordering.includes(id)) {
+                        ordering.push(id);
+                    }
+                });
+                return ordering.length ? ordering : defaultOrder;
+            }
+
+            function buildWidgetList(state) {
+                widgetList.innerHTML = '';
+                var orderedWidgets = widgets.slice();
+                var ordering = getOrder(state ? state.order : []);
+                orderedWidgets.sort(function(a, b) {
+                    return ordering.indexOf(a.dataset.widgetId) - ordering.indexOf(b.dataset.widgetId);
+                });
+
+                orderedWidgets.forEach(function(widget) {
+                    var item = document.createElement('li');
+                    item.className = 'list-group-item d-flex align-items-center gap-2 dashboard-widget-item';
+                    item.dataset.widgetId = widget.dataset.widgetId;
+                    item.setAttribute('draggable', 'true');
+
+                    var handle = document.createElement('span');
+                    handle.className = 'dashboard-widget-handle text-muted';
+                    handle.innerHTML = '<i class="ti ti-grip-vertical"></i>';
+
+                    var checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.className = 'form-check-input mt-0';
+                    checkbox.checked = !(state && Array.isArray(state.hidden) && state.hidden.includes(widget.dataset.widgetId));
+                    checkbox.setAttribute('aria-label', 'Toggle ' + widget.dataset.widgetTitle);
+
+                    var label = document.createElement('span');
+                    label.className = 'flex-grow-1';
+                    label.textContent = widget.dataset.widgetTitle;
+
+                    item.appendChild(handle);
+                    item.appendChild(checkbox);
+                    item.appendChild(label);
+                    widgetList.appendChild(item);
+                });
+
+                attachDragHandlers();
+            }
+
+            function applyState(state) {
+                var orderedIds = getOrder(state ? state.order : []);
+                var hiddenIds = state && Array.isArray(state.hidden) ? state.hidden : [];
+
+                orderedIds.forEach(function(id) {
+                    var widget = widgetContainer.querySelector('[data-widget-id="' + id + '"]');
+                    if (widget) {
+                        widgetContainer.appendChild(widget);
+                    }
+                });
+
+                widgets.forEach(function(widget) {
+                    var isHidden = hiddenIds.includes(widget.dataset.widgetId);
+                    widget.classList.toggle('d-none', isHidden);
+                });
+            }
+
+            function collectState() {
+                var items = Array.from(widgetList.querySelectorAll('[data-widget-id]'));
+                var order = items.map(function(item) { return item.dataset.widgetId; });
+                var hidden = items.filter(function(item) {
+                    var checkbox = item.querySelector('input[type="checkbox"]');
+                    return checkbox && !checkbox.checked;
+                }).map(function(item) { return item.dataset.widgetId; });
+
+                return { order: order, hidden: hidden };
+            }
+
+            var dragBound = false;
+
+            function attachDragHandlers() {
+                var items = widgetList.querySelectorAll('.dashboard-widget-item');
+                items.forEach(function(item) {
+                    item.addEventListener('dragstart', function(event) {
+                        item.classList.add('dragging');
+                        event.dataTransfer.setData('text/plain', item.dataset.widgetId);
+                        event.dataTransfer.effectAllowed = 'move';
+                    });
+
+                    item.addEventListener('dragend', function() {
+                        item.classList.remove('dragging');
+                    });
+                });
+                if (!dragBound) {
+                    widgetList.addEventListener('dragover', function(event) {
+                        event.preventDefault();
+                        var dragging = widgetList.querySelector('.dragging');
+                        if (!dragging) {
+                            return;
+                        }
+                        var afterElement = getDragAfterElement(widgetList, event.clientY);
+                        if (afterElement == null) {
+                            widgetList.appendChild(dragging);
+                        } else {
+                            widgetList.insertBefore(dragging, afterElement);
+                        }
+                    });
+                    dragBound = true;
+                }
+            }
+
+            function getDragAfterElement(container, y) {
+                var elements = Array.from(container.querySelectorAll('.dashboard-widget-item:not(.dragging)'));
+                return elements.reduce(function(closest, child) {
+                    var box = child.getBoundingClientRect();
+                    var offset = y - box.top - box.height / 2;
+                    if (offset < 0 && offset > closest.offset) {
+                        return { offset: offset, element: child };
+                    }
+                    return closest;
+                }, { offset: Number.NEGATIVE_INFINITY, element: null }).element;
+            }
+
+            var initialState = loadState();
+            applyState(initialState);
+            buildWidgetList(initialState);
+
+            widgetSave.addEventListener('click', function() {
+                var state = collectState();
+                saveState(state);
+                applyState(state);
+            });
+
+            widgetReset.addEventListener('click', function() {
+                localStorage.removeItem(storageKey);
+                var resetState = loadState();
+                applyState(resetState);
+                buildWidgetList(resetState);
+            });
         });
     </script>
 }


### PR DESCRIPTION
### Motivation
- Allow users to choose which dashboard widgets are shown and to reorder them by dragging so the dashboard can be personalized and reflect frequently used info.

### Description
- Enhanced `Views/Home/Dashboard.cshtml` to add a "Customize Widgets" toolbar button, a modal UI listing widgets with checkboxes, and widget metadata attributes (`data-dashboard-widget`, `data-widget-id`, `data-widget-title`).
- Wrapped dashboard sections in a container `#dashboard-widgets` and annotated each widget with IDs so they can be shown/hidden and reordered programmatically.
- Added client-side JavaScript that builds the modal list, supports drag-and-drop reordering, toggles visibility, and persists state to `localStorage` under `myPhotoBiz.dashboard.widgets` with a reset option.
- Added small CSS helpers for draggable list items and handles and improved ordering logic to fall back to a sane default order when saved state is missing or partial.

### Testing
- No automated tests were executed; an attempt to start the app with `dotnet run --project myPhotoBiz.csproj` failed because the `dotnet` runtime was not available in the environment, so runtime/integration verification could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697328c85f1483288f244c71830f2b5d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard is now fully customizable—reorder and toggle widget visibility to suit your workflow.
  * Drag-and-drop support for easy widget reordering.
  * New dashboard widgets available: Client Proofs, Upcoming Shoots, Recent Invoices, and Recent Activity.
  * Your dashboard configuration is automatically saved and persists across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->